### PR TITLE
Use `gen/elements` instead of `gen/one-of`

### DIFF
--- a/test/automat/core_simple_check.clj
+++ b/test/automat/core_simple_check.clj
@@ -23,9 +23,7 @@
 ;;;
 
 (def input
-  (gen/one-of
-    [(gen/return :a)
-     (gen/return :b)]))
+  (gen/elements [:a :b]))
 
 (def input-stream
   (gen/list input))


### PR DESCRIPTION
`gen/elements` doesn't require you to wrap the values in a generator
monad.
