### PR TITLE
Supply missing argument to dfa/nfa in maybe

### DIFF
--- a/src/automat/fsm.clj
+++ b/src/automat/fsm.clj
@@ -641,7 +641,8 @@
   ((if (deterministic? fsm) dfa nfa)
    (start fsm)
    (conj (accept fsm) (start fsm))
-   (zipmap* (states fsm) #(input->state fsm %))))
+   (zipmap* (states fsm) #(input->state fsm %))
+   (zipmap* (states fsm) #(input->actions fsm %))))
 
 (defn- merge-fsms [a b accept-states]
   (let [a (gensym-states (->dfa a))


### PR DESCRIPTION
This causes `a/?` to fail in 0.1.2.
