### PR TITLE
actions associated with `all-automaton` are not triggered

### DIFF
--- a/test/automat/core_test.clj
+++ b/test/automat/core_test.clj
@@ -90,6 +90,9 @@
     [1 (a/$ :conj) (a/$ :conj)]
     [[1] [1]]
 
+    [1 a/any (a/$ :conj) 3 4 (a/$ :conj)]
+    [[2 4] [1 2 3 4]]
+
     [(a/or
        (a/interpose-$ :conj [1 2 3])
        [4])


### PR DESCRIPTION
``` clojure
(require '[automat.core :as a])

(-> [1 2 (a/$ :conj) 3 4 (a/$ :conj)]
    (a/compile {:reducers {:conj conj}})
    (a/find [] [1 2 3 4])
    :value)
;=> [2 4]

(-> [1 a/any (a/$ :conj) 3 4 (a/$ :conj)]
    (a/compile {:reducers {:conj conj}})
    (a/find [] [1 2 3 4])
    :value)
;=> [4]
```

This PR adds a test case for the broken functionality.
