### PR TITLE
reducer functions are called with coerced input

### DIFF
--- a/test/automat/core_test.clj
+++ b/test/automat/core_test.clj
@@ -100,6 +100,12 @@
     [1 a/any (a/$ :conj) 3 4 (a/$ :conj)]
     [[2 4] [1 2 3 4]]
 
+    (a/interpose-$ :conj (vec "abc"))
+    [(vec "abc") (vec "abc")]
+
+    (a/interpose-$ :conj [\a :b "c"])
+    [[\a :b "c"] [\a :b "c"]]
+
     [(a/or
        (a/interpose-$ :conj [1 2 3])
        [4])


### PR DESCRIPTION
``` clojure
(-> (a/interpose-$ :conj (vec "abc"))
    (a/compile {:reducers {:conj conj}})
    (a/find [] (seq "abc"))
    :value)
;=> [97 98 99]

(-> (a/interpose-$ :conj [\a :b "c"])
    (a/compile {:reducers {:conj conj}})
    (a/find [] [\a :b "c"])
    :value)
;=> [97 :b]
```

I don't know why `99`/`"c"` is missing in the second example.
