### PR TITLE
update link to full documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ These automata, once compiled, are quite fast.  An array with 100 million elemen
 [automat "0.1.3"]
 ```
 
-Full documentation can be found [here](http://ideolalia.com/automat).
+Full documentation can be found [here](http://ideolalia.com/automat/automat.core.html).
 
 ### defining an FSM
 


### PR DESCRIPTION
Previous link "http://ideolalia.com/automat" just shows the documentation for automat.viz namespace and the updated link "http://ideolalia.com/automat/automat.core.html" shows both core and viz namespaces (at least when I try them).