### PR TITLE
restart with original-input instead of input

### DIFF
--- a/src/automat/compiler/base.cljc
+++ b/src/automat/compiler/base.cljc
@@ -61,7 +61,7 @@
                 (recur
                   (if (= state 0)
                     (signal (stream/next-input stream ::eof))
-                    input)
+                    original-input)
                   value'
                   0
                   stream-index'


### PR DESCRIPTION
When restart? is true, recur with original-input instead of input. Otherwise, the signal function will be again applied on the signal instead of the input.