### PR TITLE
Make FSMs serializable

### DIFF
--- a/src/automat/fsm.cljc
+++ b/src/automat/fsm.cljc
@@ -26,6 +26,7 @@
    descriptor
    sub-states
    action]
+  #?(:clj java.io.Serializable)
   Object
   #?(:clj (hashCode [_]
                     (p/+
@@ -137,7 +138,7 @@
                  (->> state->input->states keys set)
                  (->> state->input->states vals (mapcat vals) (apply set/union)))
         alphabet (apply set/union (->> state->input->states vals (map keys) (map set)))]
-    (reify IAutomaton
+    (reify #?(:clj java.io.Serializable) IAutomaton
       (deterministic? [_] false)
       (start [_] start)
       (accept [_] accept)
@@ -181,7 +182,7 @@
                  (->> state->input->state vals (mapcat vals) set))
         alphabet (apply set/union (->> state->input->state vals (map keys) (map set)))]
 
-    (reify IAutomaton
+    (reify #?(:clj java.io.Serializable) IAutomaton
       (deterministic? [_] true)
       (start [_] start)
       (accept [_] accept)


### PR DESCRIPTION
I'm using automat with Apache Spark. In order to avoid repeatedly recompiling my FSM, I compile it on the driver then send the compiled FSM to the executors, which requires them to be serializable.

It would be great if you are willing to merge this, so that I (and anyone else in a similar situation) don't have to maintain a separate fork.

I was only able to get `:base` compiled automatons to work, but not `:eval`, because deserialization requires the class to be available in the jar, and the eval one doesn't generate a class file when aot compiled.

This works as long as I specify `:backend :base` when compiling the FSM, but I was wondering what are the consequences of this? Presumably the the `:eval` backend is some sort of optimisation? What are the differences between the backends?