### PR TITLE
Issue #40 fixed

### DIFF
--- a/src/automat/fsm.cljc
+++ b/src/automat/fsm.cljc
@@ -421,18 +421,26 @@
 
 ;; union-find, basically
 (defn- merge-pairs [pairs]
-  (let [m (reduce
-            (fn [m [a b]]
-              (let [x (get m a (get m b a))]
-                (assoc m a x b x)))
-            {}
-            pairs)
-        root (fn root [x]
-               (let [x' (get m x)]
-                 (if (= x x')
-                   x
-                   (recur x'))))]
-    (zipmap* (keys m) root)))
+  (let [grouped (group-by (partial apply =) pairs)
+        pairs-dif (get grouped false)
+        pairs-eq  (get grouped true)
+
+        m (reduce (fn [m [a b]]
+                    (if (contains? m a)
+                      (assoc m b a)
+                      (if (contains? m b)
+                        (assoc m a b)
+                        (assoc m a a b a))))
+                  {}
+                  pairs-dif)
+
+        m (reduce (fn [m [a _]]
+                    (if (contains? m a)
+                      m
+                      (assoc m a a)))
+                  m
+                  pairs-eq)]
+   m))
 
 (defn- reduce-states [fsm]
   (let [accept (accept fsm)


### PR DESCRIPTION
There was a bug in merge-pairs function which leaded to infinite loop.
It occured for example for input: [[0 0] [1 1] [2 2] [3 0] [2 0] [3 2] [3 3]]
Infinite loop between states means that states are equal.